### PR TITLE
ログインしたことのあるuserが再度ログインした時、access_tokenを更新する

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,6 +12,7 @@ class SessionsController < ApplicationController
 
     response = oauth_access(params[:code])
 
+    access_token = response.dig(:access_token)
     authentication_params = {
       slack_workspace_id: response.dig(:team, :id),
       slack_user_id: response.dig(:user, :id)
@@ -19,7 +20,7 @@ class SessionsController < ApplicationController
     authentication = Authentication.find_or_initialize_by(authentication_params)
 
     if authentication.new_record?
-      authentication.access_token = response.dig(:access_token)
+      authentication.access_token = access_token
       user_params = {
         name: response.dig(:user, :name),
         avatar_url: response.dig(:user, :image_192)
@@ -28,6 +29,8 @@ class SessionsController < ApplicationController
 
       login(user)
     else
+      authentication.update!(access_token: access_token)
+
       login(authentication.user)
     end
 


### PR DESCRIPTION
- 仕様変更によりscopeが変わる可能性があるため(その場合access_tokenも変わる)
- slack上の操作等でaccess_tokenがrevokeされている可能性があるため