### PR TITLE
SlackのScopeを書き変える

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -27,7 +27,7 @@ class SessionsController < ApplicationController
 
       login(user)
     else
-      authentication.update!(access_token: access_token)
+      authentication.update_access_token!(access_token)
 
       login(authentication.user)
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,18 +16,14 @@ class SessionsController < ApplicationController
 
     access_token = response.dig(:access_token)
     authentication_params = {
-      slack_workspace_id: response.dig(:team, :id),
-      slack_user_id: response.dig(:user, :id)
+      slack_workspace_id: response.dig(:team_id),
+      slack_user_id: response.dig(:user_id)
     }
     authentication = Authentication.find_or_initialize_by(authentication_params)
 
     if authentication.new_record?
       authentication.access_token = access_token
-      user_params = {
-        name: response.dig(:user, :name),
-        avatar_url: response.dig(:user, :image_192)
-      }
-      user = User.create_with!(authentication, user_params)
+      user = User.create_with!(authentication)
 
       login(user)
     else

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -13,4 +13,17 @@ class Authentication < ApplicationRecord
     }
     "https://slack.com/oauth/authorize?#{params.to_query}"
   end
+
+  def update_access_token!(new_access_token)
+    if access_token != new_access_token
+      begin
+        Slack::Web::Client.new(token: access_token).auth_revoke
+        Rails.logger.info "[completed] to revoke access token. authentication_id=#{id}"
+      rescue => e
+        Rails.logger.error "[failed] to revoke access token. authentication_id=#{id}"
+        Rails.logger.error e
+      end
+      update!(access_token: new_access_token)
+    end
+  end
 end

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -7,7 +7,7 @@ class Authentication < ApplicationRecord
 
   def self.authorize_url(callback_url)
     params = {
-      scope: 'identity.basic,identity.avatar',
+      scope: 'channels:read,emoji:read,chat:write:user',
       client_id: ENV['SLACK_CLIENT_ID'],
       redirect_uri: callback_url
     }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,13 @@ class User < ApplicationRecord
 
   validates :name, presence: true
 
-  def self.create_with!(authentication, user_params)
+  def self.create_with!(authentication)
     ApplicationRecord.transaction do
+      response = Slack::Web::Client.new(token: authentication.access_token).users_identity
+      user_params = {
+        name: response.dig(:user, :name),
+        avatar_url: response.dig(:user, :image_192)
+      }
       user = User.create!(user_params)
       authentication.user = user
       authentication.save!


### PR DESCRIPTION
チャンネルリストの読み出し、絵文字の読み出し、メッセージ投稿、の3つができるscopeにする