### PR TITLE
usernameでメンションを飛ばせるようにする

### DIFF
--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -78,7 +78,8 @@ class Reminder < ApplicationRecord
       text: message,
       as_user: false,
       icon_emoji: ":#{icon_emoji}:",
-      username: icon_name
+      username: icon_name,
+      link_names: true,
     }
     begin
       user.slack_client.chat_postMessage(params)


### PR DESCRIPTION
- link_namesパラメータをtrueで渡すようにした
- https://workspace-name.slack.com/account/settings#username に書かれているusernameでメンションを飛ばせるようになる