### PR TITLE
users.profile:readスコープを使わないようにする

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -23,7 +23,7 @@ class SessionsController < ApplicationController
 
     if authentication.new_record?
       authentication.access_token = access_token
-      user = User.create_with!(authentication)
+      user = User.create_with!(authentication, response.dig(:user_id))
 
       login(user)
     else

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -7,7 +7,7 @@ class Authentication < ApplicationRecord
 
   def self.authorize_url(callback_url)
     params = {
-      scope: 'channels:read,emoji:read,chat:write:bot,users.profile:read',
+      scope: 'channels:read,emoji:read,chat:write:bot',
       client_id: ENV['SLACK_CLIENT_ID'],
       redirect_uri: callback_url
     }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,12 +9,11 @@ class User < ApplicationRecord
   enumerize :role, in: {none: 0, admin: 1},
             default: :none, predicates: {prefix: true}, scope: true
 
-  def self.create_with!(authentication)
+  def self.create_with!(authentication, user_name)
     ApplicationRecord.transaction do
-      response = Slack::Web::Client.new(token: authentication.access_token).users_profile_get
       user_params = {
-        name: response.dig(:profile, :real_name),
-        avatar_url: response.dig(:profile, :image_192)
+        name: user_name,
+        avatar_url: nil
       }
       user = User.create!(user_params)
       authentication.user = user


### PR DESCRIPTION
- プロフィール取得APIを使ってユーザ名とユーザアイコンを取得してきて保存するようになっている
- そのAPIのレスポンスにはメールアドレスなどの個人情報も含まれていて、アプリケーション内では保持していないものの、なんとなく危ういよなぁと思った
- ので、そのAPIは使わないことにした
